### PR TITLE
Update filesize guess

### DIFF
--- a/R/guess_fileSize.R
+++ b/R/guess_fileSize.R
@@ -28,22 +28,38 @@ guess_fileSize <- function(root = ".", .ignore = NULL) {
 
   ## check for .Rbuildignore, everything listed should be excluded since
   ## it will not become part of the final package
-  rbuildignore_path <- file.path(root,".Rbuildignore")
-  if (file.exists(rbuildignore_path) && is.null(.ignore)){
+  rbuildignore_path <- file.path(root, ".Rbuildignore")
+  if (file.exists(rbuildignore_path) && is.null(.ignore)) {
     .ignore <- readLines(normalizePath(rbuildignore_path), warn = FALSE)
+    .ignore <- .ignore[.ignore != ""] # eliminate blank lines
 
-  }else{
+  } else {
     .ignore <- " "
 
   }
 
   ## grep all files of interest (exclude hidden files)
-  files <- normalizePath(list.files(
-    path = normalizePath(root),
-    recursive = TRUE,
-    full.names = TRUE,
-    all.files = FALSE
-  ))
+  ## winslash = "/" is used in all normalizePath() calls to allow gsub() matching.
+  files <- normalizePath(
+    list.files(
+      path = normalizePath(root),
+      recursive = TRUE,
+      full.names = TRUE,
+      all.files = FALSE
+    ),
+    winslash = "/"
+  )
+
+  ## make paths relative to root
+  files <- gsub(paste0(normalizePath(root, winslash = "/"), "/"), "", files)
+
+  ## exclude full dirs matching an ignore pattern
+  dirs <- list.dirs(normalizePath(root, winslash = "/"))
+  dirs <- gsub(paste0(normalizePath(root, winslash = "/"), "/"), "", dirs)
+  ignore_dirs <- dirs[grepl(paste(.ignore, collapse = "|"), dirs, perl = TRUE)]
+  files <- files[
+    !grepl(paste0("^", ignore_dirs, collapse = "|"), files, perl = TRUE)
+  ]
 
   ## kick-out all files that do not belong to the R package
   files <-


### PR DESCRIPTION
Hi @cboettig , thanks for the package!

I recently switched from `codemetar` to `codemeta`. I noticed that the file size computation of both packages differ, being closer to the actual size of the package (taking into account `.Rbuildignore`) the one provided by `codemetar`.

This PR just ports the corresponding fragment of code to  `codemeta`. 

https://github.com/ropensci/codemetar/blob/c114f9a23b69d0500bbbda0be5c8dc99a18154ba/R/guess_other_metadata.R#L43-L89

See here the change of file size using this fork on a package on CRAN:

https://github.com/dieghernan/giscoR/commit/b69bc031f916baa0dbb100e984beb7bcfd510b97

Glad to hear from you, regards
