### PR TITLE
Add meta$ parsing

### DIFF
--- a/R/codemeta_description.R
+++ b/R/codemeta_description.R
@@ -132,7 +132,9 @@ add_repository_terms <- function(codemeta, descr) {
     } else {
 
       # try to identify a code repo, select the first match
-      i <- which(lapply(source_code_domains(), grepl, code_repo)[[1]])
+      # This is a safer version
+      i <- grep(paste(source_code_domains(), collapse = "|"),
+                code_repo)[1]
       actual_code_repo <- code_repo[i][1]
 
       # otherwise take the first URL arbitrarily

--- a/R/codemeta_description.R
+++ b/R/codemeta_description.R
@@ -81,7 +81,7 @@ codemeta_description <- function(file,
   }
 
   codemeta$identifier <- package_name
-  codemeta$description <- descr$get("Description")
+  codemeta$description <- clean_str(descr$get("Description"))
   codemeta$name <- paste0(package_name, ": ", descr$get("Title"))
 
   ## add repository related terms

--- a/R/parse_citation.R
+++ b/R/parse_citation.R
@@ -142,46 +142,6 @@ guess_citation <- function(path) {
   ## drop self-citation file?
 }
 
-# read_citation_with_encoding --------------------------------------------------
-read_citation_with_encoding <- function(citation_file,
-                                        meta = list(Encoding = "UTF-8")) {
-
-    ## try to read citation file
-  citation <- try(utils::readCitationFile(citation_file,
-                                          meta = meta),
-                  silent = TRUE)
-
-  ## if this fails for a very specific reason, namely a line similar to
-  ## citation(auto = meta), this line gets removed and we continue working
-  ## with a temporary CITATION file
-  if(inherits(citation, "try-error")){
-    if(grepl(pattern = "Error in.+?auto", citation[1])){
-      ## >> (1) read original CITATION file
-      temp_citation <-
-        readLines(
-          con = citation_file,
-          encoding = if (!is.na(meta$Encoding)) meta$Encoding else "unknown")
-
-      ## >> (2) remove citation(auto = meta)
-      repl_id <- which(grepl(
-        pattern = "citation\\s*\\(auto\\s*=\\s*meta\\s*\\)",
-        x = temp_citation
-        ))
-      temp_citation <- temp_citation[-repl_id]
-
-      ## >> (3) write new temporary citation file
-      temp_file <- tempfile()
-      writeLines(temp_citation, temp_file)
-
-      ## >> (4) apply extraction
-      citation <- utils::readCitationFile(temp_file, meta = meta)
-    }
-  }
-
-  return(citation)
-}
-
-
 #' Parse and clean data from DESCRIPTION to create metadata
 #' @noRd
 parse_package_meta <- function(desc_path) {

--- a/R/parse_citation.R
+++ b/R/parse_citation.R
@@ -135,7 +135,7 @@ guess_citation <- function(path) {
   meta <- parse_package_meta(file.path(path, "DESCRIPTION"))
 
   # Read and parse CITATION
-  bib <- read_citation_with_encoding(citation_path, meta)
+  bib <- utils::readCitationFile(citation_path, meta)
 
   lapply(bib, parse_citation)
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -4,61 +4,6 @@ drop_null <- function(x) {
   x[lengths(x) != 0]
 }
 
-# get_root_path ----------------------------------------------------------------
-get_root_path <- function(pkg) {
-
-  if (is_installed(pkg)) {
-
-    find.package(pkg)
-
-  } else if (is_package(file.path(pkg))) {
-
-    pkg
-
-  } else if (is.character(pkg)) {
-
-    pkg # use pkg as guess anyway
-
-# } else {
-#
-#   "." # stick with default
-  }
-}
-
-# package_file -----------------------------------------------------------------
-# Just a shortcut to system.file(..., package = pkg)
-package_file <- function(pkg, ...) {
-
-  system.file(..., package = pkg)
-}
-
-# is_installed: is the package installed -------------------------
-is_installed <- function(pkg) {
-
-  length(
-    find.package(
-      package = pkg,
-      quiet = TRUE
-      )
-    ) > 0
-}
-
-# get_file ---------------------------------------------------------------------
-## Like system.file, but pkg can instead be path to package root directory
-get_file <- function(FILE, pkg = ".") {
-
-  path <- file.path(pkg, FILE)
-
-  if (file.exists(path)) {
-
-    path
-
-  } else {
-
-    package_file(pkg, FILE)
-  }
-}
-
 # is_IRI -----------------------------------------------------------------------
 is_IRI <- function(string) {
 
@@ -67,94 +12,26 @@ is_IRI <- function(string) {
   grepl("^http[s]?://", string)
 }
 
-
-
-# whether_provider_badge -------------------------------------------------------
-whether_provider_badge <- function(badges, provider_name) {
-
-  ! is.null(provider_name) && (
-    (
-      provider_name == "Comprehensive R Archive Network (CRAN)" &&
-        any(grepl("CRAN", badges$text))
-    ) || (
-      provider_name == "BioConductor" &&
-        any(grepl("bioconductor", badges$link))
-    )
-  )
-}
-
-# is_package: helper to find whether a path is a package project ---------------
-is_package <- function(path) {
-
-  all(c("DESCRIPTION", "NAMESPACE", "man", "R") %in% dir(path))
-}
-
-# set_element ----------------------------------------------
-set_element <- function(x, element, value) {
-
-  stopifnot(is.list(x))
-
-  x[[element]] <- value
-
-  x
-
-}
-
-
-# fails ------------------------------------------------------------------------
-#' Does the Evaluation of an Expression Fail?
-#'
-#' @param expr expression to be evaluated within `try(\dots)`
-#' @param silent passed to [try()], see there.
-#' @return `TRUE` if evaluating `expr` failed and `FALSE` if
-#'   the evalutation of `expr` succeeded.
-#' @noRd
-fails <- function(expr, silent = TRUE) {
-
-  inherits(try(expr, silent = silent), "try-error")
-}
-
-# example_file -----------------------------------------------------------------
-example_file <- function(...) {
-
-  package_file("codemetar", "examples", ...)
-}
-
-
-#' Check for Class "json" or Character
-#'
-#' @param x object to be checked for its class and mode
-#' @return `TRUE` if `x` inherits from "json" or is of mode character,
-#'   otherwise `FALSE`
-#' @noRd
-is_json_or_character <- function(x) {
-
-  is(x, "json") || is.character(x)
-}
-
-
-# call_if ----------------------------------------------------------------------
-
-#' Call Function if Condition is Met
-#'
-#' @param condition expression to be evaluated
-#' @param FUN function to be called if `condition` is met
-#' @param x first argument to be passed to `FUN` or not
-#' @param \dots further arguments passed to `FUN`
-#' @noRd
-call_if <- function(condition, x, FUN, ...) {
-
-  if (condition) {
-
-    FUN(x, ...)
-
-  } else {
-
-    x
+# clean_str -----------------------
+clean_str <- function(str) {
+  # Collapse to single char
+  str <- paste(str, collapse = " ")
+  if (length(str) == 0 || is.null(str) || is.na(str) ||
+      str == "NA") {
+    return(NULL)
   }
-}
 
-# bind df -----------------------
-bind_df <- function(dfs) {
-  do.call("rbind", dfs)
+  clean <- gsub("[\n\r]", " ", str)
+  clean <- gsub("\\s+", " ", clean)
+  clean <- gsub("\\s+", " ", clean)
+  clean <- gsub("\\{", "", clean)
+  clean <- gsub("\\}", "", clean)
+  # Collapse to single char
+  clean <- paste(clean, collapse = " ")
+
+  if (clean == "") {
+    return(NULL)
+  }
+
+  clean
 }

--- a/tests/testthat/_snaps/parse_citation.md
+++ b/tests/testthat/_snaps/parse_citation.md
@@ -45,13 +45,13 @@
 
 # We can parse citations with citation(auto = meta)
 
-    [1] "rmarkdown citation parsed with codemeta DESCRIPTION"
+    [1] "citation with citation(auto = meta)"
     [[1]]
     [[1]]$`@type`
-    [1] "ScholarlyArticle"
+    [1] "SoftwareSourceCode"
     
     [[1]]$datePublished
-    [1] "2016"
+    [1] "2021"
     
     [[1]]$author
     [[1]]$author[[1]]
@@ -64,74 +64,151 @@
     [[1]]$author[[1]]$familyName
     [1] "Boettiger"
     
+    [[1]]$author[[1]]$email
+    [1] "cboettig@gmail.com"
+    
+    [[1]]$author[[1]]$`@id`
+    [1] "https://orcid.org/0000-0002-1642-628X"
+    
     
     [[1]]$author[[2]]
     [[1]]$author[[2]]$`@type`
     [1] "Person"
     
     [[1]]$author[[2]]$givenName
-    [1] "Scott"
+    [1] "Maëlle"
     
     [[1]]$author[[2]]$familyName
-    [1] "Chamberlain"
+    [1] "Salmon"
     
-    
-    [[1]]$author[[3]]
-    [[1]]$author[[3]]$`@type`
-    [1] "Person"
-    
-    [[1]]$author[[3]]$givenName
-    [1] "Rutger"
-    
-    [[1]]$author[[3]]$familyName
-    [1] "Vos"
-    
-    
-    [[1]]$author[[4]]
-    [[1]]$author[[4]]$`@type`
-    [1] "Person"
-    
-    [[1]]$author[[4]]$givenName
-    [1] "Hilmar"
-    
-    [[1]]$author[[4]]$familyName
-    [1] "Lapp"
+    [[1]]$author[[2]]$`@id`
+    [1] "https://orcid.org/0000-0002-2815-0399"
     
     
     
     [[1]]$name
-    [1] "{RNeXML}: {A} Package for Reading and Writing Richly Annotated Phylogenetic, Character, and Trait Data in {R}"
+    [1] "codemeta: A Smaller 'codemetar' Package"
     
-    [[1]]$identifier
-    [1] "10.1111/2041-210X.12469"
+    [[1]]$url
+    [1] "https://CRAN.R-project.org/package=codemeta"
     
-    [[1]]$pagination
-    [1] "352--357"
+    [[1]]$description
+    [1] "R package version 0.1.0"
     
-    [[1]]$`@id`
-    [1] "https://doi.org/10.1111/2041-210X.12469"
     
-    [[1]]$sameAs
-    [1] "https://doi.org/10.1111/2041-210X.12469"
+    [[2]]
+    [[2]]$`@type`
+    [1] "ScholarlyArticle"
     
-    [[1]]$isPartOf
-    [[1]]$isPartOf$`@type`
-    [1] "PublicationIssue"
-    
-    [[1]]$isPartOf$datePublished
+    [[2]]$datePublished
     [1] "2016"
     
-    [[1]]$isPartOf$isPartOf
-    [[1]]$isPartOf$isPartOf$`@type`
+    [[2]]$author
+    [[2]]$author[[1]]
+    [[2]]$author[[1]]$`@type`
+    [1] "Person"
+    
+    [[2]]$author[[1]]$givenName
+    [1] "Carl"
+    
+    [[2]]$author[[1]]$familyName
+    [1] "Boettiger"
+    
+    
+    [[2]]$author[[2]]
+    [[2]]$author[[2]]$`@type`
+    [1] "Person"
+    
+    [[2]]$author[[2]]$givenName
+    [1] "Scott"
+    
+    [[2]]$author[[2]]$familyName
+    [1] "Chamberlain"
+    
+    
+    [[2]]$author[[3]]
+    [[2]]$author[[3]]$`@type`
+    [1] "Person"
+    
+    [[2]]$author[[3]]$givenName
+    [1] "Rutger"
+    
+    [[2]]$author[[3]]$familyName
+    [1] "Vos"
+    
+    
+    [[2]]$author[[4]]
+    [[2]]$author[[4]]$`@type`
+    [1] "Person"
+    
+    [[2]]$author[[4]]$givenName
+    [1] "Hilmar"
+    
+    [[2]]$author[[4]]$familyName
+    [1] "Lapp"
+    
+    
+    
+    [[2]]$name
+    [1] "{RNeXML}: {A} Package for Reading and Writing Richly Annotated Phylogenetic, Character, and Trait Data in {R}"
+    
+    [[2]]$identifier
+    [1] "10.1111/2041-210X.12469"
+    
+    [[2]]$pagination
+    [1] "352--357"
+    
+    [[2]]$`@id`
+    [1] "https://doi.org/10.1111/2041-210X.12469"
+    
+    [[2]]$sameAs
+    [1] "https://doi.org/10.1111/2041-210X.12469"
+    
+    [[2]]$isPartOf
+    [[2]]$isPartOf$`@type`
+    [1] "PublicationIssue"
+    
+    [[2]]$isPartOf$datePublished
+    [1] "2016"
+    
+    [[2]]$isPartOf$isPartOf
+    [[2]]$isPartOf$isPartOf$`@type`
     [1] "PublicationVolume" "Periodical"       
     
-    [[1]]$isPartOf$isPartOf$volumeNumber
+    [[2]]$isPartOf$isPartOf$volumeNumber
     [1] "7"
     
-    [[1]]$isPartOf$isPartOf$name
+    [[2]]$isPartOf$isPartOf$name
     [1] "Methods in Ecology and Evolution"
     
     
+    
+    
+    [[3]]
+    [[3]]$`@type`
+    [1] "Book"
+    
+    [[3]]$datePublished
+    [1] "2016"
+    
+    [[3]]$author
+    [[3]]$author[[1]]
+    [[3]]$author[[1]]$`@type`
+    [1] "Person"
+    
+    [[3]]$author[[1]]$givenName
+    [1] "Hadley"
+    
+    [[3]]$author[[1]]$familyName
+    [1] "Wickham"
+    
+    
+    
+    [[3]]$name
+    [1] "ggplot2: Elegant Graphics for Data Analysis"
+    
+    [[3]]$url
+    [1] "https://ggplot2.tidyverse.org"
     
     
 

--- a/tests/testthat/_snaps/parse_citation.md
+++ b/tests/testthat/_snaps/parse_citation.md
@@ -1,0 +1,137 @@
+# We can parse meta tags
+
+    [1] "rmarkdown citation parsed with codemeta DESCRIPTION"
+    [[1]]
+    [[1]]$`@type`
+    [1] "SoftwareSourceCode"
+    
+    [[1]]$datePublished
+    [1] "2021"
+    
+    [[1]]$author
+    [[1]]$author[[1]]
+    [[1]]$author[[1]]$`@type`
+    [1] "Person"
+    
+    [[1]]$author[[1]]$givenName
+    [1] "Carl"
+    
+    [[1]]$author[[1]]$familyName
+    [1] "Boettiger"
+    
+    
+    [[1]]$author[[2]]
+    [[1]]$author[[2]]$`@type`
+    [1] "Person"
+    
+    [[1]]$author[[2]]$givenName
+    [1] "Maëlle"
+    
+    [[1]]$author[[2]]$familyName
+    [1] "Salmon"
+    
+    
+    
+    [[1]]$name
+    [1] "rmarkdown: A Smaller 'codemetar' Package"
+    
+    [[1]]$url
+    [1] "https://github.com/cboettig/codemeta"
+    
+    [[1]]$description
+    [1] "R package version 0.1.0"
+    
+    
+
+# We can parse citations with citation(auto = meta)
+
+    [1] "rmarkdown citation parsed with codemeta DESCRIPTION"
+    [[1]]
+    [[1]]$`@type`
+    [1] "ScholarlyArticle"
+    
+    [[1]]$datePublished
+    [1] "2016"
+    
+    [[1]]$author
+    [[1]]$author[[1]]
+    [[1]]$author[[1]]$`@type`
+    [1] "Person"
+    
+    [[1]]$author[[1]]$givenName
+    [1] "Carl"
+    
+    [[1]]$author[[1]]$familyName
+    [1] "Boettiger"
+    
+    
+    [[1]]$author[[2]]
+    [[1]]$author[[2]]$`@type`
+    [1] "Person"
+    
+    [[1]]$author[[2]]$givenName
+    [1] "Scott"
+    
+    [[1]]$author[[2]]$familyName
+    [1] "Chamberlain"
+    
+    
+    [[1]]$author[[3]]
+    [[1]]$author[[3]]$`@type`
+    [1] "Person"
+    
+    [[1]]$author[[3]]$givenName
+    [1] "Rutger"
+    
+    [[1]]$author[[3]]$familyName
+    [1] "Vos"
+    
+    
+    [[1]]$author[[4]]
+    [[1]]$author[[4]]$`@type`
+    [1] "Person"
+    
+    [[1]]$author[[4]]$givenName
+    [1] "Hilmar"
+    
+    [[1]]$author[[4]]$familyName
+    [1] "Lapp"
+    
+    
+    
+    [[1]]$name
+    [1] "{RNeXML}: {A} Package for Reading and Writing Richly Annotated Phylogenetic, Character, and Trait Data in {R}"
+    
+    [[1]]$identifier
+    [1] "10.1111/2041-210X.12469"
+    
+    [[1]]$pagination
+    [1] "352--357"
+    
+    [[1]]$`@id`
+    [1] "https://doi.org/10.1111/2041-210X.12469"
+    
+    [[1]]$sameAs
+    [1] "https://doi.org/10.1111/2041-210X.12469"
+    
+    [[1]]$isPartOf
+    [[1]]$isPartOf$`@type`
+    [1] "PublicationIssue"
+    
+    [[1]]$isPartOf$datePublished
+    [1] "2016"
+    
+    [[1]]$isPartOf$isPartOf
+    [[1]]$isPartOf$isPartOf$`@type`
+    [1] "PublicationVolume" "Periodical"       
+    
+    [[1]]$isPartOf$isPartOf$volumeNumber
+    [1] "7"
+    
+    [[1]]$isPartOf$isPartOf$name
+    [1] "Methods in Ecology and Evolution"
+    
+    
+    
+    
+

--- a/tests/testthat/test-minimeta.R
+++ b/tests/testthat/test-minimeta.R
@@ -1,7 +1,8 @@
 
 test_that("write_codemeta", {
 
-  path <- system.file("", package="codemeta")
+  # Safer version
+  path <- find.package("codemeta")
   codemeta.json <- tempfile(fileext =".json")
   write_codemeta(path, file = codemeta.json)
 

--- a/tests/testthat/test-parse_citation.R
+++ b/tests/testthat/test-parse_citation.R
@@ -49,7 +49,7 @@ test_that("We can parse meta tags", {
   meta <- parse_package_meta(d)
 
   # Read and parse CITATION
-  bib <- read_citation_with_encoding(c, meta)
+  bib <- utils::readCitationFile(c, meta)
   expect_s3_class(bib, "citation")
 
   bibs <- lapply(bib, parse_citation)
@@ -63,12 +63,21 @@ test_that("We can parse meta tags", {
 
 test_that("We can parse citations with citation(auto = meta)", {
   c <- test_path("test_examples", "citation_auto", "CITATION_")
-  bib <- read_citation_with_encoding(c)
+
+  # Need that file to completely parse all the tags
+  d <- test_path("test_examples", "rmarkdown", "DESCRIPTION_codemeta_from_cran_")
+
+  # Read DESCRIPTION to determine meta
+  meta <- parse_package_meta(d)
+  bib <- utils::readCitationFile(c, meta)
+  expect_true(length(bib) == 3)
+
+  expect_s3_class(bib, "citation")
 
   bibs <- lapply(bib, parse_citation)
   expect_type(bibs, "list")
   expect_snapshot_output({
-    print("rmarkdown citation parsed with codemeta DESCRIPTION")
-    print(bibs[1])
+    print("citation with citation(auto = meta)")
+    print(bibs)
   })
 })

--- a/tests/testthat/test-parse_citation.R
+++ b/tests/testthat/test-parse_citation.R
@@ -3,7 +3,7 @@ test_that("We can parse_citation",{
   f <- test_path("test_examples", "RNeXML", "CITATION_")
   bib <- readCitationFile(f)
   schema <- lapply(bib, parse_citation)
-  expect_is(schema, "list")
+  expect_type(schema, "list")
   expect_equal(schema[[1]][["@type"]], "ScholarlyArticle")
 
 })
@@ -38,4 +38,37 @@ test_that("We can parse citations", {
   ## not a package path returns null and doesn't error
   gc_null <- guess_citation(file.path(examples_path, "not-a-package"))
   expect_null(gc_null)
+})
+
+test_that("We can parse meta tags", {
+  c <- test_path("test_examples", "rmarkdown", "CITATION_")
+  # Need that file to completely parse all the tags
+  d <- test_path("test_examples", "rmarkdown", "DESCRIPTION_codemeta_from_cran_")
+
+  # Read DESCRIPTION to determine meta
+  meta <- parse_package_meta(d)
+
+  # Read and parse CITATION
+  bib <- read_citation_with_encoding(c, meta)
+  expect_s3_class(bib, "citation")
+
+  bibs <- lapply(bib, parse_citation)
+  expect_type(bibs, "list")
+  expect_snapshot_output({
+    print("rmarkdown citation parsed with codemeta DESCRIPTION")
+    print(bibs[1])
+  })
+})
+
+
+test_that("We can parse citations with citation(auto = meta)", {
+  c <- test_path("test_examples", "citation_auto", "CITATION_")
+  bib <- read_citation_with_encoding(c)
+
+  bibs <- lapply(bib, parse_citation)
+  expect_type(bibs, "list")
+  expect_snapshot_output({
+    print("rmarkdown citation parsed with codemeta DESCRIPTION")
+    print(bibs[1])
+  })
 })

--- a/tests/testthat/test_examples/citation_auto/CITATION_
+++ b/tests/testthat/test_examples/citation_auto/CITATION_
@@ -1,0 +1,28 @@
+citation(auto = meta)
+bibentry(bibtype = "Article",
+         header = "To cite RNeXML in publications, please use:",
+         title = "{RNeXML}: {A} Package for Reading and Writing Richly Annotated Phylogenetic, Character, and Trait Data in {R}",
+         journal = "Methods in Ecology and Evolution",
+         author = c(
+             person("Carl", "Boettiger"),
+             person("Scott", "Chamberlain"),
+             person("Rutger", "Vos"),
+             person("Hilmar", "Lapp")),
+         year = 2016,
+         volume = 7,
+         pages = "352--357",
+         doi = "10.1111/2041-210X.12469")
+
+bibentry(bibtype = "Article",
+         header = "To cite RNeXML in publications, please use:",
+         title = "{RNeXML}: {A} Package for Reading and Writing Richly Annotated Phylogenetic, Character, and Trait Data in {R}",
+         journal = "Methods in Ecology and Evolution",
+         author = c(
+             person("Carl", "Boettiger"),
+             person("Scott", "Chamberlain"),
+             person("Rutger", "Vos"),
+             person("Hilmar", "Lapp")),
+         year = 2016,
+         volume = 7,
+         pages = "352--357",
+         doi = "https://doi.org/10.1111/2041-210X.12469")

--- a/tests/testthat/test_examples/citation_auto/CITATION_
+++ b/tests/testthat/test_examples/citation_auto/CITATION_
@@ -13,16 +13,12 @@ bibentry(bibtype = "Article",
          pages = "352--357",
          doi = "10.1111/2041-210X.12469")
 
-bibentry(bibtype = "Article",
-         header = "To cite RNeXML in publications, please use:",
-         title = "{RNeXML}: {A} Package for Reading and Writing Richly Annotated Phylogenetic, Character, and Trait Data in {R}",
-         journal = "Methods in Ecology and Evolution",
-         author = c(
-             person("Carl", "Boettiger"),
-             person("Scott", "Chamberlain"),
-             person("Rutger", "Vos"),
-             person("Hilmar", "Lapp")),
-         year = 2016,
-         volume = 7,
-         pages = "352--357",
-         doi = "https://doi.org/10.1111/2041-210X.12469")
+citEntry(entry = "book",
+  author = "Hadley Wickham",
+  title = "ggplot2: Elegant Graphics for Data Analysis",
+  publisher = "Springer-Verlag New York",
+  year = "2016",
+  isbn = "978-3-319-24277-4",
+  url = "https://ggplot2.tidyverse.org",
+  textVersion = "H. Wickham. ggplot2: Elegant Graphics for Data Analysis. Springer-Verlag New York, 2016."
+)

--- a/tests/testthat/test_examples/rmarkdown/CITATION_
+++ b/tests/testthat/test_examples/rmarkdown/CITATION_
@@ -1,0 +1,51 @@
+citHeader("To cite the 'rmarkdown' package in publications, please use:")
+
+year = sub('.*(2[[:digit:]]{3})-.*', '\\1', meta$Date, perl = TRUE)
+if (length(year) == 0) year = format(Sys.Date(), '%Y')
+vers = paste('R package version', meta$Version)
+auth = format(Filter(function(p) 'aut' %in% p$role, as.person(meta$Author)), c('given', 'family'))
+
+citEntry(
+  entry = 'manual',
+  title = paste('rmarkdown:', meta$Title),
+  author = auth,
+  year = year,
+  note = vers,
+  url = strsplit(meta$URL, ',')[[1]][1],
+  textVersion = paste0(
+    paste(auth, collapse = ' and '), ' (', year, '). rmarkdown: ', meta$Title, '. ', vers, '.',
+    ' URL https://rmarkdown.rstudio.com.'
+  )
+)
+
+citEntry(
+  entry = 'book',
+  title = 'R Markdown: The Definitive Guide',
+  author = c('Yihui Xie', 'J.J. Allaire', 'Garrett Grolemund'),
+  publisher = 'Chapman and Hall/CRC',
+  address = 'Boca Raton, Florida',
+  year = '2018',
+  note = 'ISBN 9781138359338',
+  url = 'https://bookdown.org/yihui/rmarkdown',
+  textVersion = paste(
+    'Yihui Xie and J.J. Allaire and Garrett Grolemund (2018).',
+    'R Markdown: The Definitive Guide.', 'Chapman and Hall/CRC. ISBN 9781138359338.',
+    'URL https://bookdown.org/yihui/rmarkdown.'
+  )
+)
+
+citEntry(
+  entry = 'book',
+  title = 'R Markdown Cookbook',
+  author = c('Yihui Xie', 'Christophe Dervieux', 'Emily Riederer'),
+  publisher = 'Chapman and Hall/CRC',
+  address = 'Boca Raton, Florida',
+  year = '2020',
+  note = 'ISBN 9780367563837',
+  url = 'https://bookdown.org/yihui/rmarkdown-cookbook',
+  textVersion = paste(
+    'Yihui Xie and Christophe Dervieux and Emily Riederer (2020).',
+    'R Markdown Cookbook.', 'Chapman and Hall/CRC. ISBN 9780367563837.',
+    'URL https://bookdown.org/yihui/rmarkdown-cookbook.'
+  )
+)

--- a/tests/testthat/test_examples/rmarkdown/DESCRIPTION_codemeta_from_cran_
+++ b/tests/testthat/test_examples/rmarkdown/DESCRIPTION_codemeta_from_cran_
@@ -1,7 +1,7 @@
 Type: Package
 Package: codemeta
 Title: A Smaller 'codemetar' Package
-Version: 0.1.1
+Version: 0.1.0
 Authors@R: 
     c(person(given = "Carl",
              family = "Boettiger",
@@ -54,22 +54,29 @@ Description: The 'Codemeta' Project defines a 'JSON-LD' format
 License: GPL-3
 URL: https://github.com/cboettig/codemeta
 BugReports: https://github.com/cboettig/codemeta/issues
-Depends: 
-    R (>= 3.0.0)
-Imports: 
-    desc,
-    jsonlite (>= 1.6),
-    methods,
-    utils
-Suggests: 
-    covr,
-    knitr,
-    rmarkdown,
-    testthat (>= 3.0.0)
+Depends: R (>= 3.0.0)
+Imports: desc, jsonlite (>= 1.6), methods, utils
+Suggests: covr, knitr, rmarkdown, testthat (>= 2.1.0)
 Encoding: UTF-8
-RoxygenNote: 7.1.2
+RoxygenNote: 7.1.1
 X-schema.org-isPartOf: https://ropensci.org
-X-schema.org-keywords: metadata, codemeta, ropensci, citation,
-    credit, linked-data
-Roxygen: list(markdown = TRUE)
-Config/testthat/edition: 3
+X-schema.org-keywords: metadata, codemeta, ropensci, citation, credit,
+        linked-data
+NeedsCompilation: no
+Packaged: 2021-07-20 23:29:02 UTC; cboettig
+Author: Carl Boettiger [aut, cre, cph]
+    (<https://orcid.org/0000-0002-1642-628X>),
+  Maëlle Salmon [ctb, aut] (<https://orcid.org/0000-0002-2815-0399>),
+  Katrin Leinweber [ctb] (<https://orcid.org/0000-0001-5135-5758>),
+  Noam Ross [ctb] (<https://orcid.org/0000-0002-2136-0000>),
+  Arfon Smith [ctb],
+  Jeroen Ooms [ctb] (<https://orcid.org/0000-0002-4035-0289>),
+  Sebastian Meyer [ctb] (<https://orcid.org/0000-0002-1791-9449>),
+  Michael Rustler [ctb] (<https://orcid.org/0000-0003-0647-7726>),
+  Hauke Sonnenberg [ctb] (<https://orcid.org/0000-0001-9134-2871>),
+  Sebastian Kreutzer [ctb] (<https://orcid.org/0000-0002-0734-2199>),
+  rOpenSci [fnd] (https://ropensci.org/)
+Maintainer: Carl Boettiger <cboettig@gmail.com>
+Repository: CRAN
+Date/Publication: 2021-07-22 06:40:02 UTC
+Built: R 4.1.1; ; 2021-09-03 15:29:48 UTC; windows


### PR DESCRIPTION
Closes #7 

I have adapted the chunk of code of **{cffr}** for parsing `meta$` tags on CITATION (it has been extensively tested on ~2000 packages: see [here](https://github.com/dieghernan/cffr/blob/main/tests/testthat/test_local_installation/_snaps/full_cff.md)) to **{codemeta}**.

Other changes you would see on the PR:
* Test suit added with snapshots. Also new test files added, included `CITATION` from  `rmardown`.
* Legacy utils functions of **{codemetar}** deleted. They were not used in **{codemeta}**.
* A safer way to `grep` the `source_code_domains`. Previous version thrown sometimes an error.
* RoxygenNote updated due to new version on CRAN of **{roxygen2}**.
* **{testthat}** upgraded, since snapshots were implemented on `(>= 3.0.0)`. This also means that `expect_is`  (deprecated on `(>= 3.0.0)` should be replaced with `expect_type`.


Ping @dpprdan 

Regards