### PR TITLE
add cache for available_source_packages()

### DIFF
--- a/R/guess_provider.R
+++ b/R/guess_provider.R
@@ -1,29 +1,7 @@
-
-## FIXME create local cache
-CRAN <- function() {
-
-  data <- suppressWarnings(
-    available_source_packages("https://cran.rstudio.com"))
-
-  return(data)
-}
-
-BIOC <- function() {
-
-  data <- suppressWarnings(
-    available_source_packages("https://www.bioconductor.org/packages/release/bioc"))
-
-  return(data)
-}
-
-
 # guess_provider ---------------------------------------------------------------
 guess_provider <- function(pkg, verbose = FALSE) {
 
-  if (is.null(pkg)) {
-
-    return(NULL)
-  }
+  if (is.null(pkg)) return(NULL)
 
   ## Assumes a single provider
   if (is_cran_package(pkg, verbose)) {
@@ -46,26 +24,39 @@ guess_provider <- function(pkg, verbose = FALSE) {
   }
 }
 
-#
-# Helper functions can later be moved to utils.R
-#
-
 # available_source_packages ----------------------------------------------------
-available_source_packages <- function(url) {
+codemeta_cache_env <- new.env(parent = emptyenv())
 
-  utils::available.packages(utils::contrib.url(url, "source"))
+available_source_packages <- function(repo = c("CRAN", "BIOC")) {
+
+  url <-
+    switch(
+      repo,
+      CRAN = "https://cloud.r-project.org",
+      BIOC = "https://www.bioconductor.org/packages/release/bioc",
+      stop("Only CRAN and BIOC repos are supported.")
+    )
+
+  contrib_url <- utils::contrib.url(url, "source")
+
+  if (is.null(codemeta_cache_env[[repo]])) {
+    codemeta_cache_env[[repo]] <- utils::available.packages(contrib_url)
+  }
+
+  suppressWarnings(codemeta_cache_env[[repo]])
+
 }
 
 # is_cran_package --------------------------------------------------------------
 is_cran_package <- function(pkg, verbose = FALSE) {
 
-  is_in_package_info(pkg, CRAN())
+  is_in_package_info(pkg, available_source_packages("CRAN"))
 }
 
 # is_bioconductor_package ------------------------------------------------------
 is_bioconductor_package <- function(pkg, verbose = FALSE) {
 
-  is_in_package_info(pkg, BIOC())
+  is_in_package_info(pkg, available_source_packages("BIOC"))
 }
 
 # is_in_package_info -----------------------------------------------------------

--- a/tests/testthat/test-guess_provider.R
+++ b/tests/testthat/test-guess_provider.R
@@ -1,0 +1,23 @@
+test_that("guess_provider() works",{
+  skip_on_cran()
+  skip_if_offline()
+
+  expect_null(guess_provider(NULL))
+
+  ## A BIOC package
+  expect_equal(guess_provider("a4")$name, "BioConductor")
+  ## A CRAN package
+  expect_equal(
+    guess_provider("jsonlite")$name,
+    "Comprehensive R Archive Network (CRAN)"
+  )
+})
+
+test_that("available_source_packages() uses cache", {
+  skip_on_cran()
+  skip_if_offline()
+
+  # available_source_packages have been added to cache by calls above
+  expect_false(is.null(codemeta_cache_env$CRAN))
+  expect_false(is.null(codemeta_cache_env$BIOC))
+})


### PR DESCRIPTION
Prompted by the source code comment, this PR adds a cache to `available_source_packages()`, effectively calling `utils::available.packages()` only once per R session. This reduces the time used by `write_codemeta()` significantly:


``` r
# Current master without cache
library(codemeta)
system.time(write_codemeta(find.package("dplyr"), file = NULL))
#>    user  system elapsed 
#>   33.60    0.64   34.66
```

``` r
# This branch with cache
library(codemeta)
system.time(write_codemeta(find.package("dplyr"), file = NULL))
#>    user  system elapsed 
#>    1.18    0.12    2.64
```

Note that `utils::available.packages()` already uses a cache, but it's on-disk instead of in-memory, so it still takes 2 sec for each call (i.e. each package dependency in this case) on my machine. By default, `utils::available.packages()` cache is invalidated after one hour, see [Details in the help file](https://rdrr.io/r/utils/available.packages.html). 

`available_source_packages()` is not invalidated as long as the R session is still alive. 