### PR TITLE
remove URI fragment from codeRepository URL

### DIFF
--- a/R/codemeta_description.R
+++ b/R/codemeta_description.R
@@ -127,7 +127,7 @@ add_repository_terms <- function(codemeta, descr) {
     if (length(code_repo) == 1) {
 
       # only one, easy
-      codemeta$codeRepository <- code_repo
+      actual_code_repo <- code_repo
 
     } else {
 
@@ -138,11 +138,7 @@ add_repository_terms <- function(codemeta, descr) {
       actual_code_repo <- code_repo[i][1]
 
       # otherwise take the first URL arbitrarily
-      if (is.na(actual_code_repo)) {
-        codemeta$codeRepository <- code_repo[1]
-      } else {
-        codemeta$codeRepository <- actual_code_repo
-      }
+      if (is.na(actual_code_repo)) actual_code_repo <- code_repo[1]
 
       # add other URLs as related links
       codemeta$relatedLink <- unique(c(
@@ -150,6 +146,8 @@ add_repository_terms <- function(codemeta, descr) {
         code_repo[code_repo != actual_code_repo]
       ))
     }
+
+    codemeta$codeRepository <- gsub("#(.*)$", "", actual_code_repo)
   }
 
   codemeta

--- a/tests/testthat/test-add_repository_terms.R
+++ b/tests/testthat/test-add_repository_terms.R
@@ -18,12 +18,13 @@ test_that("add_repository_terms works", {
 test_that("add_repository_terms updates the codeRepository URL", {
   skip_on_cran()
   skip_if_offline()
+
   cm <- new_codemeta()
   cm$codeRepository <- "lalala"
   desc_path <- test_path("test_examples", "DESCRIPTION_twomaintainers")
   descr <- desc::desc(desc_path)
-
   cm <- add_repository_terms(cm, descr = descr)
+
   expect_equal(cm$codeRepository, "https://github.com/ropensci/codemetar")
   expect_true("https://ropensci.github.io/codemetar" %in% cm$relatedLink)
 })
@@ -57,5 +58,17 @@ test_that("add_repository_terms works with non-GitHub-repository", {
       codemeta = new_codemeta(),
       descr = desc::desc(desc_path)
     )
+
   expect_equal(cm$codeRepository, "https://git.rud.is/hrbrmstr/hrbragg")
+  expect_true("https://rud.is/b" %in% cm$relatedLink)
+})
+
+test_that("add_repository_terms removes URI fragment from codeRepository URL", {
+  skip_on_cran()
+  skip_if_offline()
+
+  desc_path <- test_path("test_examples", "cli", "DESCRIPTION")
+  cm <- codemeta_description(desc_path)
+  expect_equal(cm$codeRepository, "https://github.com/r-lib/cli")
+  expect_true("https://cli.r-lib.org" %in% cm$relatedLink)
 })

--- a/tests/testthat/test_examples/cli/DESCRIPTION
+++ b/tests/testthat/test_examples/cli/DESCRIPTION
@@ -1,0 +1,49 @@
+Package: cli
+Title: Helpers for Developing Command Line Interfaces
+Version: 3.0.1.9000
+Authors@R: c(
+    person("Gábor", "Csárdi", , "csardi.gabor@gmail.com", c("aut", "cre")),
+    person("Hadley", "Wickham", role = c("ctb")),
+    person("Kirill", "Müller", role = c("ctb")),
+    person("RStudio", role = "cph")
+    )
+Description: A suite of tools to build attractive command line interfaces
+    ('CLIs'), from semantic elements: headings, lists, alerts, paragraphs,
+    etc. Supports custom themes via a 'CSS'-like language. It also contains a
+    number of lower level 'CLI' elements: rules, boxes, trees, and
+    'Unicode' symbols with 'ASCII' alternatives. It support ANSI colors and
+    text styles as well.
+License: MIT + file LICENSE
+URL: https://cli.r-lib.org, https://github.com/r-lib/cli#readme
+BugReports: https://github.com/r-lib/cli/issues
+RoxygenNote: 7.1.2
+Roxygen: list(
+     markdown = TRUE,
+     knitr_chunk_options = list(cache = TRUE, error = TRUE, cache.path = "man/_cache/")
+   )
+Depends: R (>= 2.10)
+Imports:
+    glue,
+    utils
+Suggests:
+    asciicast,
+    callr,
+    covr,
+    grDevices,
+    htmltools,
+    htmlwidgets,
+    knitr,
+    methods,
+    mockery,
+    processx,
+    ps (>= 1.3.4.9000),
+    rlang,
+    rmarkdown,
+    rstudioapi,
+    shiny,
+    testthat,
+    tibble,
+    whoami,
+    withr
+Config/testthat/edition: 3
+Encoding: UTF-8

--- a/tests/testthat/test_examples/hrbragg/DESCRIPTION
+++ b/tests/testthat/test_examples/hrbragg/DESCRIPTION
@@ -19,7 +19,7 @@ Description: The 'ragg', 'systemfonts', and 'textshaping' packages make it
     the rich typography features in modern fonts. Fonts, themes, and utilities
     are provided to create 'ggplot2' plots intended for rendering on 'ragg'
     graphics devices.
-URL: https://git.rud.is/hrbrmstr/hrbragg
+URL: https://git.rud.is/hrbrmstr/hrbragg, https://rud.is/b
 BugReports: https://git.rud.is/hrbrmstr/hrbragg/issues
 Encoding: UTF-8
 Copyright: file inst/COPYRIGHTS


### PR DESCRIPTION
This removes the URI fragment from the codeRepository URL, closes #13