### PR TITLE
restore verbose option with message()

### DIFF
--- a/R/guess_provider.R
+++ b/R/guess_provider.R
@@ -15,7 +15,7 @@ guess_provider <- function(pkg, verbose = FALSE) {
 
     new_codemeta_organization(
       url = "https://www.bioconductor.org",
-      name = "BioConductor"
+      name = "Bioconductor"
     )
 
   } else {
@@ -27,20 +27,28 @@ guess_provider <- function(pkg, verbose = FALSE) {
 # available_source_packages ----------------------------------------------------
 codemeta_cache_env <- new.env(parent = emptyenv())
 
-available_source_packages <- function(repo = c("CRAN", "BIOC")) {
+available_source_packages <- function(
+  repo = c("CRAN", "Bioconductor"),
+  verbose = FALSE
+) {
 
   url <-
     switch(
       repo,
-      CRAN = "https://cloud.r-project.org",
-      BIOC = "https://www.bioconductor.org/packages/release/bioc",
-      stop("Only CRAN and BIOC repos are supported.")
+      CRAN         = "https://cloud.r-project.org",
+      Bioconductor = "https://www.bioconductor.org/packages/release/bioc",
+      stop("Only CRAN and Bioconductor repos are supported.")
     )
 
   contrib_url <- utils::contrib.url(url, "source")
 
   if (is.null(codemeta_cache_env[[repo]])) {
+
+    if (verbose) message(paste("Getting", repo, "metadata..."))
+
     codemeta_cache_env[[repo]] <- utils::available.packages(contrib_url)
+
+    if (verbose) message(paste("Got", repo, "metadata!"))
   }
 
   suppressWarnings(codemeta_cache_env[[repo]])
@@ -50,13 +58,16 @@ available_source_packages <- function(repo = c("CRAN", "BIOC")) {
 # is_cran_package --------------------------------------------------------------
 is_cran_package <- function(pkg, verbose = FALSE) {
 
-  is_in_package_info(pkg, available_source_packages("CRAN"))
+  is_in_package_info(pkg, available_source_packages("CRAN", verbose = verbose))
 }
 
 # is_bioconductor_package ------------------------------------------------------
 is_bioconductor_package <- function(pkg, verbose = FALSE) {
 
-  is_in_package_info(pkg, available_source_packages("BIOC"))
+  is_in_package_info(
+    pkg,
+    available_source_packages("Bioconductor", verbose = verbose)
+  )
 }
 
 # is_in_package_info -----------------------------------------------------------

--- a/R/parse_depends.R
+++ b/R/parse_depends.R
@@ -37,7 +37,7 @@ get_sameAs <- function(provider, remote_provider, identifier) {
   # assign each keyword a function that returns the URL to a given package name
   url_generators <- list(
     "Comprehensive R Archive Network (CRAN)" = get_url_cran_package,
-    "BioConductor" = get_url_bioconductor_package
+    "Bioconductor" = get_url_bioconductor_package
   )
 
   # The remote provider takes precedence over the non-remote provider

--- a/R/write_codemeta.R
+++ b/R/write_codemeta.R
@@ -4,6 +4,8 @@
 #' @param path path to the package root
 #' @param id identifier for the package (e.g. a DOI, as URL)
 #' @param file output file location, should be called `codemeta.json`.
+#' @param verbose Whether to print messages indicating the progress of internet
+#'   downloads.
 #' @return a codemeta list object (invisbly) and write out the codemeta.json file
 #' @export
 #' @examples
@@ -17,11 +19,16 @@
 #'  write_codemeta(path, file = out)
 #' }
 #' @importFrom jsonlite write_json
-write_codemeta <- function(path = ".", id = NULL, file = "codemeta.json"){
+write_codemeta <- function(
+  path = ".",
+  id = NULL,
+  file = "codemeta.json",
+  verbose = getOption("verbose", FALSE)
+){
 
   ## get information from DESCRIPTION
   descr <- file.path(path, "DESCRIPTION")
-  cm <- codemeta_description(descr, id = id)
+  cm <- codemeta_description(descr, id = id, verbose = verbose)
   cm$fileSize <- guess_fileSize(path)
   cm$citation <- guess_citation(path)
 

--- a/man/write_codemeta.Rd
+++ b/man/write_codemeta.Rd
@@ -4,7 +4,12 @@
 \alias{write_codemeta}
 \title{write_codemeta}
 \usage{
-write_codemeta(path = ".", id = NULL, file = "codemeta.json")
+write_codemeta(
+  path = ".",
+  id = NULL,
+  file = "codemeta.json",
+  verbose = getOption("verbose", FALSE)
+)
 }
 \arguments{
 \item{path}{path to the package root}
@@ -12,6 +17,9 @@ write_codemeta(path = ".", id = NULL, file = "codemeta.json")
 \item{id}{identifier for the package (e.g. a DOI, as URL)}
 
 \item{file}{output file location, should be called \code{codemeta.json}.}
+
+\item{verbose}{Whether to print messages indicating the progress of internet
+downloads.}
 }
 \value{
 a codemeta list object (invisbly) and write out the codemeta.json file

--- a/tests/testthat/test-guess_provider.R
+++ b/tests/testthat/test-guess_provider.R
@@ -4,8 +4,8 @@ test_that("guess_provider() works",{
 
   expect_null(guess_provider(NULL))
 
-  ## A BIOC package
-  expect_equal(guess_provider("a4")$name, "BioConductor")
+  ## A Bioconductor package
+  expect_equal(guess_provider("a4")$name, "Bioconductor")
   ## A CRAN package
   expect_equal(
     guess_provider("jsonlite")$name,
@@ -19,5 +19,32 @@ test_that("available_source_packages() uses cache", {
 
   # available_source_packages have been added to cache by calls above
   expect_false(is.null(codemeta_cache_env$CRAN))
-  expect_false(is.null(codemeta_cache_env$BIOC))
+  expect_false(is.null(codemeta_cache_env$Bioconductor))
+})
+
+test_that("guess_provider() can be verbose", {
+  skip_on_cran()
+  skip_if_offline()
+
+  # First delete cache so metadata needs to be loaded again
+  codemeta_cache_env$CRAN <- NULL
+
+  # There are two messages which we need to capture
+  expect_message(
+    expect_message(
+      guess_provider("jsonlite", verbose = TRUE),
+      "Getting CRAN" # First message before fetching data
+    ),
+    "Got CRAN" # Second message when data arrived
+  )
+
+  # Now the same with Bioconductor, delete cache and capture two messages
+  codemeta_cache_env$Bioconductor <- NULL
+  expect_message(
+    expect_message(
+      guess_provider("a4", verbose = TRUE),
+      "Getting Bioconductor" # First message before fetching data
+    ),
+    "Got Bioconductor" # Second message when data arrived
+  )
 })

--- a/tests/testthat/test-parse_depends.R
+++ b/tests/testthat/test-parse_depends.R
@@ -5,7 +5,7 @@ test_that("Test the various cases for dependencies", {
   expect_error(format_depend(NULL))
   a <- format_depend(package = "a4",
                      version = "*",
-                     remote_provider = "")  # BIOC provider
+                     remote_provider = "")  # Bioconductor provider
   expect_equal(a$sameAs, "https://bioconductor.org/packages/release/bioc/html/a4.html")
 
 
@@ -45,7 +45,7 @@ test_that("get_sameAs() works as expected", {
   expect_null(get_sameAs(list(name = "unknown"), "", "my_package"))
 
   provider_1 <- list(name = "Comprehensive R Archive Network (CRAN)")
-  provider_2 <- list(name = "BioConductor")
+  provider_2 <- list(name = "Bioconductor")
 
   url_1 <- "https://CRAN.R-project.org/package=my_package"
   url_2 <- "https://bioconductor.org/packages/release/bioc/html/my_package.html"


### PR DESCRIPTION
This PR restores the verbose option in `write_codemeta()` and uses `message()` instead of {cli}. Closes #12